### PR TITLE
Update package-lock.json

### DIFF
--- a/Presentation/ClientApp/package-lock.json
+++ b/Presentation/ClientApp/package-lock.json
@@ -2621,7 +2621,7 @@
         "minimatch": "^3.0.4",
         "normalize-path": "^3.0.0",
         "p-limit": "^2.1.0",
-        "serialize-javascript": "^1.4.0",
+        "serialize-javascript": ">=2.1.1",
         "webpack-log": "^2.0.0"
       },
       "dependencies": {
@@ -8512,7 +8512,7 @@
       }
     },
     "serialize-javascript": {
-      "version": "1.7.0",
+      "version": ">=2.1.1",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.7.0.tgz",
       "integrity": "sha512-ke8UG8ulpFOxO8f8gRYabHQe/ZntKlcig2Mp+8+URDP1D8vJZ0KUt7LYo07q25Z/+JVSgpr/cui9PIp5H6/+nA==",
       "dev": true
@@ -9542,7 +9542,7 @@
         "cacache": "^11.0.2",
         "find-cache-dir": "^2.0.0",
         "schema-utils": "^1.0.0",
-        "serialize-javascript": "^1.4.0",
+        "serialize-javascript": ">=2.1.1",
         "source-map": "^0.6.1",
         "terser": "^3.16.1",
         "webpack-sources": "^1.1.0",


### PR DESCRIPTION
GitHub security alert to update serialize-JavaScript library to version >=2.1.1